### PR TITLE
Revert "fix: copying text in Safari"

### DIFF
--- a/src/SearchComponent.js
+++ b/src/SearchComponent.js
@@ -67,16 +67,21 @@ export class SearchComponent {
     }, false);
 
     // Activate search on any keypress
-    document.addEventListener('keydown', event => {
+    document.addEventListener('keypress', event => {
       if (this.input === document.activeElement)
         return;
-      if (event.ctrlKey || event.metaKey || event.altKey)
-        return;
-      if (/\S/.test(event.key) || event.keyCode === 8 || event.keyCode === 46) {
+      if (/\S/.test(event.key)) {
         this.input.focus();
         if (event.key !== '.')
           this.input.value = '';
       }
+    }, false);
+    // Activate search on backspace
+    document.addEventListener('keydown', event => {
+      if (this.input === document.activeElement)
+        return;
+      if (event.keyCode === 8 || event.keyCode === 46)
+        this.input.focus();
     }, false);
     // Activate on paste
     document.addEventListener('paste', event => {


### PR DESCRIPTION
Reverts GoogleChromeLabs/pptr.dev#4

This breaks keyboard navigation, e.g. after typing a search term and selecting it with "enter", the search field remains empty.